### PR TITLE
fix: Make spawn process work on Windows

### DIFF
--- a/demo/test-n3-engine.ts
+++ b/demo/test-n3-engine.ts
@@ -58,7 +58,7 @@ ex:zeno a foaf:Person.
 
 
 const eyeJs = new EyeJsReasoner()
-const eye = new EyeReasoner('/usr/local/bin/eye', ["--quiet", "--nope", "--pass-only-new"])
+const eye = new EyeReasoner('eye', ["--quiet", "--nope", "--pass-only-new"])
 const ruleDir = path.join(path.dirname(__filename), "..", "src", "rules");
 const rulePath = path.join(ruleDir, "simpleRules.n3");
 const rules = fs.readFileSync(rulePath, "utf-8");

--- a/src/reasoner/EyeReasoner.ts
+++ b/src/reasoner/EyeReasoner.ts
@@ -42,8 +42,8 @@ export class EyeReasoner extends Reasoner {
         return new Promise<string>(async (resolve, reject) => {
             let errorData = '';
             let resultData = '';
-            
-            const ls = spawn(this.eye, all_args);
+
+            const ls = spawn(this.eye, all_args, { shell: process.platform === 'win32' });
             ls.stdout.on('data', (data) => {
               resultData += data;
             });


### PR DESCRIPTION
This would make my life easier.

The Windows installation of eye is done with a batch file, which requires this setting as noted in https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows

I also changed the eye path in the test to `eye` from `/usr/local/bin/eye` so it is platform independent. Or does that break stuff for you?